### PR TITLE
DEVX-1602 Remove migration template

### DIFF
--- a/developer-portal/catalog/templates-seed-dev.yml
+++ b/developer-portal/catalog/templates-seed-dev.yml
@@ -7,5 +7,4 @@ spec:
     targets:
         - https://github.com/bcgov/devhub-templates/blob/main/software-templates/techdocs-template/template.yaml
         - https://github.com/bcgov/devhub-templates/blob/main/software-templates/techdocs-template-pr/template.yaml
-        - https://github.com/bcgov/devhub-templates/blob/main/software-templates/migrate-repo-to-enterprise/template.yaml
         

--- a/developer-portal/catalog/templates-seed-prod.yml
+++ b/developer-portal/catalog/templates-seed-prod.yml
@@ -7,4 +7,3 @@ spec:
     targets:
         - https://github.com/bcgov/devhub-templates/blob/main/software-templates/techdocs-template/template.yaml
         - https://github.com/bcgov/devhub-templates/blob/main/software-templates/techdocs-template-pr/template.yaml
-        - https://github.com/bcgov/devhub-templates/blob/main/software-templates/migrate-repo-to-enterprise/template.yaml

--- a/developer-portal/catalog/templates-seed-test.yml
+++ b/developer-portal/catalog/templates-seed-test.yml
@@ -7,4 +7,3 @@ spec:
     targets:
         - https://github.com/bcgov/devhub-templates/blob/main/software-templates/techdocs-template/template.yaml
         - https://github.com/bcgov/devhub-templates/blob/main/software-templates/techdocs-template-pr/template.yaml
-        - https://github.com/bcgov/devhub-templates/blob/main/software-templates/migrate-repo-to-enterprise/template.yaml


### PR DESCRIPTION
Remove the migration template that moved repos from bcgov GitHub org to the bcgov-public GitHub org. This template is no longer needed.

