### PR TITLE
devxt-2340: Added popular-in-so label functionality

### DIFF
--- a/utils/stackoverflow/README.md
+++ b/utils/stackoverflow/README.md
@@ -119,6 +119,7 @@ python populate_discussion.py --repo OWNER/REPO --category CATEGORY_NAME [option
 - `--api-delay`: Minimum seconds between API calls (default: 1.0)
 - `--ignore-tags`: List of tags to ignore (space-separated). Questions tagged with these tag(s) will not be processed.
 - `--tag-min-threshold`: Minimum number of questions a tag must be associated with to be considered for label creation (default: 1)
+- `--popular-tag-min-threshold`: Minimum number of views a question must have in SO for the `popular-in-so` label to be applied to it (default: 200)
 
 #### Example
 ```

--- a/utils/stackoverflow/populate_discussion.py
+++ b/utils/stackoverflow/populate_discussion.py
@@ -569,6 +569,21 @@ def load_id_mapping(mapping_file: str) -> Dict[str, str]:
         logger.error(f"Error loading ID mapping file {mapping_file}: {e}")
         raise
 
+
+def is_popular(question: Dict[str, Any], popular_tag_min_threshold: int) -> bool:
+    """
+    Determine if a question is popular based on view count.
+
+    Args:
+        question: The question data dictionary
+        popular_tag_min_threshold: The minimum view count to be considered popular
+
+    Returns:
+        True if the the view_count is at or above the threshold, False otherwise
+    """
+    view_count = question.get('view_count', 0)
+    return view_count >= popular_tag_min_threshold
+
 def main():
     # Setup logging for this script
     setup_populate_discussion_logging()
@@ -595,6 +610,11 @@ def main():
                          type=int,
                          default=1,
                          help='Minimum number of questions a tag must be associated with to be considered for label creation (default: 1)')
+    parser.add_argument('--popular-tag-min-threshold',
+                         type=int,
+                         default=200,
+                         help='Minimum number of views a question must have in SO for the `popular-in-so` label to be applied to it (default: 200)')
+    
     args = parser.parse_args()
 
     if args.tag_min_threshold < 0:
@@ -605,12 +625,17 @@ def main():
         logger.warning("Negative API delay specified, defaulting to 1.0 seconds")
         args.api_delay = 1.0
 
+    if args.popular_tag_min_threshold < 0:
+        logger.warning("Negative popular tag minimum threshold specified, defaulting to 200")
+        args.popular_tag_min_threshold = 200
+
     # Set the global API delay based on user preference
     rate_limiter = RateLimiter(min_interval=args.api_delay)
     logger.info(f"Using API delay of {args.api_delay} seconds between requests")
 
     SO_LINK = "link"
     SO_SHARE_LINK = "share_link"
+    POPULAR_TAG_NAME = "popular-in-so"
 
     # Initialize GitHub authentication
     github_auth_manager = GitHubAuthManager()
@@ -663,6 +688,10 @@ def main():
         if tag_name not in existing_labels and not tags_to_ignore_helper.should_ignore([tag_name]):
             create_label(repo, tag_name, description)
 
+    # Add popular tag label if it doesn't exist
+    if POPULAR_TAG_NAME not in existing_labels:
+        create_label(repo, POPULAR_TAG_NAME, f'This question was viewed at least {args.popular_tag_min_threshold} times on BC Gov Stack Overflow')
+
     logger.info(f"category_id for '{args.category}': {category_id}")
 
     # Process questions with limit if specified
@@ -691,6 +720,8 @@ def main():
                 continue
             
             tags = remove_tags_under_threshold(tags_under_threshold, tags)
+            if is_popular(question, args.popular_tag_min_threshold):
+                tags.append(POPULAR_TAG_NAME)
 
             body = question.get('body', '')
 

--- a/utils/stackoverflow/so_explore.py
+++ b/utils/stackoverflow/so_explore.py
@@ -4,7 +4,7 @@ import duckdb as dd
 # dd.sql("select users.email, count(*) as question_count from './users.json' as users, './questions_answers_comments.json' as questions where questions.owner.user_id=users.user_id group by users.email order by question_count desc").show()
 # dd.sql("select len(questions.answers) from './questions_answers_comments.json' as questions").show()
 
-dd.sql("select * from './questions_answers_comments.json' as questions where questions.question_id=1297").show()
+# dd.sql("select * from './questions_answers_comments.json' as questions where questions.question_id=1297").show()
 # dd.sql("select len(questions.answers) from './questions_answers_comments.json' as questions where questions.question_id=1297").show()
 # dd.sql("select select users.emil, questions.answers.owner from './questions_answers_comments.json' as questions where questions.question_id=1297").show()
 # dd.sql("select questions.answers from './questions_answers_comments.json' as questions").show()
@@ -20,3 +20,4 @@ dd.sql("select * from './questions_answers_comments.json' as questions where que
 # dd.sql("select questions.question_id, questions.title, from './discussions_to_add.json' as questions where list_contains(questions.tags, 'openshift')").show()
 # dd.sql("select questions.question_id, questions.title, questions.tags from './discussions_to_add.json' as questions order by questions.question_id").show()
 # dd.sql("select tags.name, tags.count, age(to_timestamp(tags.last_activity_date)) from './tags.json' as tags where tags.count < 2 order by tags.last_activity_date desc, tags.count desc").show()
+dd.sql("select question_id, view_count from './questions_answers_comments.json' as questions where view_count >= 100 order by view_count desc").show()

--- a/utils/stackoverflow/test_populate_discussion.py
+++ b/utils/stackoverflow/test_populate_discussion.py
@@ -9,10 +9,38 @@ from populate_discussion import (
     TagsToIgnore,
     remove_tags_under_threshold,
     get_tags_under_threshold, 
-    get_tags_at_or_above_threshold
+    get_tags_at_or_above_threshold,
+    is_popular
 )
 
+class TestIsPopular(unittest.TestCase):
+    """Unit tests for the is_popular function."""
 
+    def test_is_popular_above_threshold(self):
+        """Test with question views above the threshold."""
+        question = {'view_count': 150}
+        threshold = 100
+        self.assertTrue(is_popular(question, threshold))
+
+    def test_is_popular_equal_to_threshold(self):
+        """Test with question views equal to the threshold."""
+        question = {'view_count': 100}
+        threshold = 100
+        self.assertTrue(is_popular(question, threshold))
+
+    def test_is_not_popular_below_threshold(self):
+        """Test with question views below the threshold."""
+        question = {'view_count': 50}
+        threshold = 100
+        self.assertFalse(is_popular(question, threshold))
+
+    def test_is_popular_no_view_count(self):
+        """Test with question that has no view count."""
+        question = {}
+        threshold = 100
+        self.assertFalse(is_popular(question, threshold))
+
+        
 class TestGetUrlRedirStr(unittest.TestCase):
     """Unit tests for the get_url_redir_str function."""
 


### PR DESCRIPTION
This PR adds the functionality to include a `popular-in-so` label to those questions that had a view_count of over X. The number can be provided at run time, but will default to 200 if not provided
