### PR TITLE
Updated to use rapidfuzz

### DIFF
--- a/utils/stackoverflow/requirements.txt
+++ b/utils/stackoverflow/requirements.txt
@@ -2,6 +2,7 @@ certifi==2023.7.22
 cffi==1.17.1
 charset-normalizer==3.2.0
 cryptography==45.0.5
+debugpy==1.8.16
 Deprecated==1.2.18
 duckdb==1.3.2
 greenlet==3.2.4
@@ -21,6 +22,7 @@ PyNaCl==1.5.0
 pytest==8.4.1
 python-dateutil==2.9.0.post0
 pytz==2025.2
+RapidFuzz==3.13.0
 requests==2.31.0
 six==1.17.0
 typing_extensions==4.14.1

--- a/utils/stackoverflow/test_populate_discussion.py
+++ b/utils/stackoverflow/test_populate_discussion.py
@@ -114,7 +114,7 @@ class TestFormatHeaderData(unittest.TestCase):
         json_data = '{"owner": {"display_name": "Test User", "user_id": "1234"},"score": 1,"creation_date": 1752172239}'
         github_mapping = {"1234": "GitHubUser1", "5678": "GitHubUser2"}
         data = json.loads(json_data)
-        expected = f"> [!NOTE]\n> Originally asked by Test User (GitHubUser1) on Jul 10, 2025 at 18:30 UTC in BC Gov Stack Overflow.\n" + \
+        expected = f"> [!NOTE]\n> Originally asked by Test User ([GitHubUser1](https://github.com/GitHubUser1)) on Jul 10, 2025 at 18:30 UTC in BC Gov Stack Overflow.\n" + \
            f"> It had 1 vote.\n\n"
         result = format_header_data(data, MetaAction.ASKED, github_mapping)
         self.assertEqual(result, expected)

--- a/utils/stackoverflow/test_validate_migration.py
+++ b/utils/stackoverflow/test_validate_migration.py
@@ -246,9 +246,10 @@ class TestMigrationValidator(unittest.TestCase):
         }
         
         issues = self.validator.validate_question_content(so_question, gh_discussion)
-        self.assertEqual(len(issues), 1)
+        self.assertEqual(len(issues), 2)
         self.assertIn("Missing images:", issues[0])
         self.assertIn("3545-sdfkb-adf2.png", issues[0])
+        self.assertIn("Body content not found", issues[1])
 
     def test_validate_question_content_with_multiple_images(self):
         """Test validation with multiple images in question body."""
@@ -548,11 +549,11 @@ class TestMigrationValidator(unittest.TestCase):
                 "nodes": [
                     # Question comments (top-level)
                     {
-                        "body": "> [!NOTE]\n> Comment by user1 on 2024-01-15\n\nGreat question!",
+                        "body": "> [!NOTE]\n> Originally commented on by user1 on 2024-01-15\n\nGreat question!",
                         "replyTo": None
                     },
                     {
-                        "body": "> [!NOTE]\n> Comment by user2 on 2024-01-15\n\nI have the same issue.",
+                        "body": "> [!NOTE]\n> Originally commented on by user2 on 2024-01-15\n\nI have the same issue.",
                         "replyTo": None
                     },
                     # Answer comments (with replies)
@@ -602,11 +603,11 @@ class TestMigrationValidator(unittest.TestCase):
                 "nodes": [
                     # Question comments (correct)
                     {
-                        "body": "> [!NOTE]\n> Comment by user1\n\nComment 1",
+                        "body": "> [!NOTE]\n> Originally commented on by user1\n\nComment 1",
                         "replyTo": None
                     },
                     {
-                        "body": "> [!NOTE]\n> Comment by user2\n\nComment 2",
+                        "body": "> [!NOTE]\n> Originally commented on by user2\n\nComment 2",
                         "replyTo": None
                     },
                     # Answer with missing reply
@@ -667,7 +668,7 @@ class TestMigrationValidator(unittest.TestCase):
                 "nodes": [
                     # Question comment (top-level)
                     {
-                        "body": "> [!NOTE]\n> Comment by user1\n\nQuestion comment",
+                        "body": "> [!NOTE]\n> Originally commented on by user1\n\nQuestion comment",
                         "replyTo": None
                     },
                     # Answer with reply
@@ -699,7 +700,7 @@ class TestMigrationValidator(unittest.TestCase):
             "comments": {
                 "nodes": [
                     {
-                        "body": "> [!NOTE]\n> Comment by user1\n\nOnly question comment",
+                        "body": "> [!NOTE]\n> Originally commented on by user1\n\nOnly question comment",
                         "replyTo": None
                     }
                 ]
@@ -794,7 +795,7 @@ class TestMigrationValidator(unittest.TestCase):
             "comments": {
                 "nodes": [
                     {
-                        "body": "> [!NOTE]\n> Comment by user1\n\nQuestion comment 1",
+                        "body": "> [!NOTE]\n> Originally commented on by user1\n\nQuestion comment 1",
                         "replyTo": None
                     },
                     # Missing second question comment
@@ -829,7 +830,7 @@ class TestMigrationValidator(unittest.TestCase):
             "comments": {
                 "nodes": [
                     {
-                        "body": "> [!NOTE]\n> Comment by user1\n\nQuestion comment",
+                        "body": "> [!NOTE]\n> Originally commented on by user1\n\nQuestion comment",
                         "replyTo": None  # Top-level question comment
                     },
                     {
@@ -870,11 +871,11 @@ class TestMigrationValidator(unittest.TestCase):
                 "nodes": [
                     # Question comments
                     {
-                        "body": "> [!NOTE]\n> Comment by user1\n\nQuestion comment 1",
+                        "body": "> [!NOTE]\n> Originally commented on by user1\n\nQuestion comment 1",
                         "replyTo": None
                     },
                     {
-                        "body": "> [!NOTE]\n> Comment by user2\n\nQuestion comment 2",
+                        "body": "> [!NOTE]\n> Originally commented on by user2\n\nQuestion comment 2",
                         "replyTo": None
                     },
                     # First answer with replies


### PR DESCRIPTION
This PR does the following:

* use rapidfuzz to check text similarity
* added `--text-similarity-percentage` argument that allows configuration of the minimum text similarity percentage between SO and GHD content to be considered the same.
* added logic to check comments text


