### PR TITLE
DEVXT-1959 - Add BC-Policy-Framework-For-GitHub to dev catalog seed

### DIFF
--- a/developer-portal/catalog/catalog-seed-dev.yml
+++ b/developer-portal/catalog/catalog-seed-dev.yml
@@ -24,3 +24,4 @@ spec:
         - https://github.com/bcgov/developer-portal/blob/main/catalog-info.yaml # don't need to promote to test or prod
         - https://github.com/bcgov/event-stream-service-techdocs/blob/main/catalog-info.yml
         - https://github.com/bcgov/design-system/blob/main/catalog-info.yaml
+        - https://github.com/bcgov/BC-Policy-Framework-For-GitHub/blob/master/catalog-info.yaml

--- a/developer-portal/catalog/catalog-seed-prod.yml
+++ b/developer-portal/catalog/catalog-seed-prod.yml
@@ -20,3 +20,4 @@ spec:
         - https://github.com/bcgov/DITP/blob/main/catalog-info.yaml
         - https://github.com/bcgov/event-stream-service-techdocs/blob/main/catalog-info.yml
         - https://github.com/bcgov/design-system/blob/main/catalog-info.yaml
+        - https://github.com/bcgov/BC-Policy-Framework-For-GitHub/blob/master/catalog-info.yaml

--- a/developer-portal/catalog/catalog-seed-test.yml
+++ b/developer-portal/catalog/catalog-seed-test.yml
@@ -15,3 +15,4 @@ spec:
         - https://github.com/bcgov/common-hosted-form-service-techdocs/blob/main/catalog-info.yml
         - https://github.com/bcgov/common-object-management-service-docs/blob/main/catalog-info.yaml
         - https://github.com/bcgov/design-system/blob/main/catalog-info.yaml
+        - https://github.com/bcgov/BC-Policy-Framework-For-GitHub/blob/master/catalog-info.yaml


### PR DESCRIPTION
Adds the policy framework repo to the DevHub catalog seed for the dev environment so the entry shows up in DevHub search.

This change is associated to bcgov/BC-Policy-Framework-For-GitHub#83, which adds the catalog-info.yaml file that this URL points at. That PR should merge first, otherwise this entry will resolve to a 404 until it does.