### PR TITLE
Add Authoritative Data Registers docs to catalog-seed-dev.yaml

### DIFF
--- a/developer-portal/catalog/catalog-seed-dev.yml
+++ b/developer-portal/catalog/catalog-seed-dev.yml
@@ -24,3 +24,4 @@ spec:
         - https://github.com/bcgov/developer-portal/blob/main/catalog-info.yaml # don't need to promote to test or prod
         - https://github.com/bcgov/event-stream-service-techdocs/blob/main/catalog-info.yml
         - https://github.com/bcgov/design-system/blob/main/catalog-info.yaml
+        - https://github.com/bcgov/adr/blob/dev/Documentation/Devhub/catalog-info.yaml

--- a/developer-portal/catalog/catalog-seed-dev.yml
+++ b/developer-portal/catalog/catalog-seed-dev.yml
@@ -24,4 +24,4 @@ spec:
         - https://github.com/bcgov/developer-portal/blob/main/catalog-info.yaml # don't need to promote to test or prod
         - https://github.com/bcgov/event-stream-service-techdocs/blob/main/catalog-info.yml
         - https://github.com/bcgov/design-system/blob/main/catalog-info.yaml
-        - https://github.com/bcgov/adr/blob/dev/Documentation/Devhub/catalog-info.yaml
+        - https://github.com/bcgov/adr/blob/dev/catalog-info.yaml


### PR DESCRIPTION
This PR adds a reference to [bcgov/adr's catalog-info.yaml file](https://github.com/bcgov/adr/blob/dev/Documentation/Devhub/catalog-info.yaml) to DevHub's `catalog-seed-dev.yaml` list.

Note that `dev` is the default branch name for bcgov/adr, and currently the only branch that holds the documentation for publishing. The Authoritative Data Registers (ADR) team will have a conversation about branch names internally before going to prod, in case it makes sense to start using the conventional `main` as the default branch name. I've purposefully only added to `-dev.yaml` and **not** `-test.yaml` or `-prod.yaml` until we decide on this.

I don't have permissions to add reviewers, but I'm tagging @MonicaG and @danilomeireles as they were in the meeting between ADR and DevX on this. Thanks in advance! 😄 